### PR TITLE
Use num lock instead of caps lock for KBDPAD MKII LED

### DIFF
--- a/keyboards/kbdfans/kbdpad_mk2/config.h
+++ b/keyboards/kbdfans/kbdpad_mk2/config.h
@@ -47,7 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* COL2ROW, ROW2COL*/
 #define DIODE_DIRECTION COL2ROW
 
-#define LED_CAPS_LOCK_PIN B4
+#define LED_NUM_LOCK_PIN B4
 #define LED_PIN_ON_STATE 0
 
 #define BACKLIGHT_PIN B7


### PR DESCRIPTION
The LED indicator on the KBDfans KBDPAD MKII is incorrectly tied to the caps lock state instead of num lock. This change fixes that.

## Types of Changes


- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #11780

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
